### PR TITLE
Make promise compatible with Angular 1.6

### DIFF
--- a/lib/net/BaseHttpClient.js
+++ b/lib/net/BaseHttpClient.js
@@ -52,17 +52,17 @@ BaseHttpClient.prototype._handleRequest = function (url, method, data, parser, h
         parser = parser || new Parser();
         var unwrapResponse = this.unwrapResponse();
         this._getNetworkPromise(url, method, data, headers, plainResponse)
-            .success(function (response, status, headers, config) {
+            .then(function (response) {
                 if (!unwrapResponse)
-                    resolve(parser.parse(response));
+                    resolve(parser.parse(response.data));
                 else
-                    resolve([parser.parse(response), status, headers, config]);
+                    resolve([parser.parse(response.data), response.status, response.headers, response.config]);
             })
-            .error(function (error, status, headers, config) {
+            .catch(function (error) {
                 if (!unwrapResponse)
                     reject(error);
                 else
-                    reject({data: error, status: status, headers: headers, config: config});
+                    reject({data: error.error, status: error.status, headers: error.headers, config: error.config});
             });
     }, this));
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "jquery": "~2.1.1"
     },
     "peerDependencies": {
-        "angular": ">=1.4.7"
+        "angular": ">=1.6.8"
     },
     "repository": {
         "type": "git",
@@ -20,7 +20,7 @@
     "devDependencies": {
         "browserify-istanbul": "~0.2.0",
         "smild": "~2.0.0",
-        "angular-mocks": "1.4.7"
+        "angular-mocks": "1.6.8"
     },
     "scripts": {
         "test": "./node_modules/.bin/smild test",


### PR DESCRIPTION
https://stackoverflow.com/questions/35329384/why-are-angular-http-success-error-methods-deprecated-removed-from-v1-6